### PR TITLE
Support custom DocumentRoot for Apache and environment-aware programs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ENV TERM xterm
 # Fix command line compile issue with bundler.
 ENV LC_ALL en_US.utf8
 
+# Custom docroot (see conf/run-httpd.sh)
+ENV DOCROOT /var/www/public
+
 # Install and enable repositories
 RUN yum -y update && \
     yum -y install epel-release && \
@@ -71,10 +74,8 @@ RUN systemctl disable httpd.service && \
 COPY public/index.php /var/www/public/index.php
 COPY centos-7 /tmp/centos-7/
 
-RUN rsync -a /tmp/centos-7/etc/httpd /etc/ && \
+RUN rsync -a /tmp/centos-7/etc/ /etc/ && \
     apachectl configtest
-
-RUN rsync -a /tmp/centos-7/etc/php.ini /etc/.
 
 EXPOSE 80 443
 

--- a/centos-7/etc/profile.d/docroot.sh
+++ b/centos-7/etc/profile.d/docroot.sh
@@ -1,0 +1,1 @@
+export DOCROOT='/var/www/public'

--- a/conf/run-httpd.sh
+++ b/conf/run-httpd.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+file_env 'DOCROOT'
+if [ ! -z "$DOCROOT" ] && ! grep -q "^DocumentRoot \"$DOCROOT\"" /etc/httpd/conf/httpd.conf ; then
+	sed -i "s#/var/www/public#$DOCROOT#g" /etc/httpd/conf/httpd.conf
+	echo "export DOCROOT='$DOCROOT'" > /etc/profile.d/docroot.sh
+fi
+
 # Make sure we're not confused by old, incompletely-shutdown httpd
 # context after restarting the container.  httpd won't start correctly
 # if it thinks it is already running.

--- a/conf/run-httpd.sh
+++ b/conf/run-httpd.sh
@@ -25,8 +25,8 @@ file_env() {
 file_env 'DOCROOT'
 if [ ! -z "$DOCROOT" ] && ! grep -q "^DocumentRoot \"$DOCROOT\"" /etc/httpd/conf/httpd.conf ; then
 	sed -i "s#/var/www/public#$DOCROOT#g" /etc/httpd/conf/httpd.conf
-	echo "export DOCROOT='$DOCROOT'" > /etc/profile.d/docroot.sh
 fi
+echo "export DOCROOT='$DOCROOT'" > /etc/profile.d/docroot.sh
 
 # Make sure we're not confused by old, incompletely-shutdown httpd
 # context after restarting the container.  httpd won't start correctly


### PR DESCRIPTION
This implements custom docroot support.

The DOCROOT environment variable is available to all future shells and can be used when invoking other programs, e.g. drush:

`drush -r "$DOCROOT" sql-connect`