### PR TITLE
Remove rm -fR on destination directory

### DIFF
--- a/conf/run-httpd.sh
+++ b/conf/run-httpd.sh
@@ -62,8 +62,7 @@ if [ -f "/var/application/.mounts" ]; then
     src=$(echo $p | cut -f1 -d:)
     dst=$(echo $p | cut -f2 -d:)
     # Removes existing files to allow symlink to apply in all cases.
-    rm -fR $dst
-    ln -s $src $dst
+    ln -sf $src $dst
     echo $src $dst
   done </var/application/.mounts
 fi


### PR DESCRIPTION
Remove rm -fR on destination directory, if the directory ends in a trailiing slash this will remove all files under the symlinked directory instead of the symlink itself, added -f flag to symlink to prevent failures.